### PR TITLE
[CssSelector] Tests on Xpath translator will always pass

### DIFF
--- a/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
@@ -114,7 +114,7 @@ class TranslatorTest extends TestCase
         $document->loadHTMLFile(__DIR__.'/Fixtures/ids.html');
         $document = simplexml_import_dom($document);
         $elements = $document->xpath($translator->cssToXPath($css));
-        $this->assertCount(\count($elementsId), $elementsId);
+        $this->assertCount(\count($elementsId), $elements);
         foreach ($elements as $element) {
             if (null !== $element->attributes()->id) {
                 $this->assertContains((string) $element->attributes()->id, $elementsId);


### PR DESCRIPTION
While working on another PR (https://github.com/symfony/symfony/pull/49388), I noticed that the assertion below will always pass as it is testing the count of the same array on both side.

| Q             | A
| ------------- | ---
| Branch?       |  5.4
| Bug fix?      |  yes
| New feature?  |  no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |  no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        |

Instead of
`$this->assertCount(\count($elementsId), $elementsId);`
It should be
`$this->assertCount(\count($elementsId), $elements);`

This PR should fix also numbers and/or Xpath translator issues from this fixed assertion.










